### PR TITLE
Create anon user slug

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,7 +12,9 @@ class User < ActiveRecord::Base
   CLIENT_ID = Rails.env.production? ? 'e0d1a9753eaf289' : '63c3978f06dac10'
   CLIENT_SECRET = Rails.env.production? ? '804e630c072f527b68bdfcc6a08ccbfe2492ab99' : '4eea9bc017f984049cfcd748fb3d8de17ae1cb8e'
 
-  before_create :assign_beta_code
+  before_create :assign_beta_code, :generate_slug
+
+  validates_presence_of :slug
 
   scope :sorted_history, order("created_at ASC")
 
@@ -95,6 +97,10 @@ class User < ActiveRecord::Base
   end
 
   protected
+
+  def generate_slug
+    self.slug = SecureRandom.uuid
+  end
 
   def assign_beta_code
     # For those who need not a code

--- a/db/migrate/20140506053816_add_secret_slug_to_users.rb
+++ b/db/migrate/20140506053816_add_secret_slug_to_users.rb
@@ -1,0 +1,6 @@
+class AddSecretSlugToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :slug, :string
+    add_index :users, :slug, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140502171522) do
+ActiveRecord::Schema.define(version: 20140506053816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -117,11 +117,13 @@ ActiveRecord::Schema.define(version: 20140502171522) do
     t.datetime "confirmed_at"
     t.datetime "confirmation_sent_at"
     t.boolean  "completed_feature_tour", default: false
+    t.string   "slug"
   end
 
   add_index "users", ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true, using: :btree
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree
   add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
+  add_index "users", ["slug"], name: "index_users_on_slug", unique: true, using: :btree
 
   create_table "votes", force: true do |t|
     t.integer  "votable_id"


### PR DESCRIPTION
Creates a string slug column with unique index.
Create user slugs for new accounts. 
Uses SecureRandom.uuid to generate => 'a3c2a991-e44a-493c-9d07-9b624a98c25'

Post deploy: create slugs for users
u = User.all; nil
u.each {|u| u.u pdate_column("slug", SecureRandom.uuid) }; nil
