### PR TITLE
Resets deprecated media.tags api to use tags_v2 (BREAKING CHANGES)

### DIFF
--- a/app/serializers/media_serializer.rb
+++ b/app/serializers/media_serializer.rb
@@ -20,7 +20,7 @@ class MediaSerializer < BaseSerializer
   end
 
   def tags
-    [media.section]
+    tags_v2
   end
 
   def tags_v2

--- a/public/js/gallery.js
+++ b/public/js/gallery.js
@@ -181,8 +181,8 @@ var gnodes = {}, current_image, favGrid, slideGallery,
 		modal.backOn();
 
 		topbar.firstChild.innerHTML = "";
-		topbar.firstChild.appendChild(voteMeter(d, true));
-		topbar.children[2].innerHTML = d.tags[0];
+		topbar.firstChild.appendChild(voteMeter(d.tags_v2, true));
+		topbar.children[2].innerHTML = Object.keys(d.tags_v2)[0];
 
 		bigpic.src = image.get(d, window.innerWidth - 40).url;
 		picdesc.innerHTML = d.caption;


### PR DESCRIPTION
The media.tags response on media requests should no longer be used. All tag information, including score is wrapped in to the media.tags_v2 node. 

Additionally, the score being rendered on the client needs consistency. 

Decisions need to be made about which scores to be used in which places as to not to seem confusing to users and not seem like the a ghost town for low voted tags.

See: https://www.pivotaltracker.com/story/show/71905842 for more information.
