### PR TITLE
Block welcomes screens

### DIFF
--- a/app/controllers/client_controller.rb
+++ b/app/controllers/client_controller.rb
@@ -103,8 +103,8 @@ class ClientController < ApplicationController
   end
 
   def welcome
-    if current_user.welcomeed?
-      redirect_to :feed
+    if current_user.welcomed?
+      redirect_to feed_path
     end
   end
 


### PR DESCRIPTION
because typos in branch names are the BOMB! :trollface: 

Block the welcome screens for a user that already has seen them. 
