### PR TITLE
nswf typo

### DIFF
--- a/app/models/media.rb
+++ b/app/models/media.rb
@@ -226,7 +226,7 @@ class Media < ActiveRecord::Base
           delete_hash: obj['deletehash']
         })
 
-        if obj["nswf"] == 'true'
+        if obj["nsfw"] == 'true'
           media.tag_list.add(media.section, 'NSFW')
         else
           media.tag_list.add(media.section)


### PR DESCRIPTION
This means many nsfw media objects may not have the tag, but still abide by the nsfw rules.

The typo fix will create the tag when these media objects are added to the system.
