### PR TITLE
Clean Tags

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141029175923) do
+ActiveRecord::Schema.define(version: 20141106005558) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Tags with special chars and whitespace are breaking our workers. Let's make sure they don't get saved, and clean the names that already exist.
